### PR TITLE
Deploy to fly, other updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.editorconfig
+.env*
+.git
+README.md
+.gitignore

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,7 @@
-[*]
+[*.{js,ts}]
 indent_style = space
 indent_size = 4
+
+[*.toml]
+indent_style = space
+indent_size = 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:17.8.0-buster-slim
 
 WORKDIR /app
-
 COPY . /app
-
 RUN npm install --production
+
+EXPOSE 3000
 
 CMD ["node", "./dist/bin/service.js"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,41 @@
+# fly.toml file generated for keeper on 2022-05-02T06:36:51-05:00
+
+app = "keeper"
+
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[env]
+  CONF_FILE = "main"
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[[services]]
+  http_checks = []
+  internal_port = 3000
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"

--- a/src/lib/clients/keeper.ts
+++ b/src/lib/clients/keeper.ts
@@ -1,12 +1,12 @@
 import { CommandClient, Command } from '../../types/generic';
-import { KeeperClientOptions, KeeperSlackMiddleware } from '../../types/clients/keeper'
+import { KeeperClientOptions, MessageEvent } from '../../types/clients/keeper'
 import KeeperCommandHandlerMap from '../handlers/keeper';
 import { Logger } from '../../types/logger';
 
 class KeeperClient implements CommandClient {
     private logger: Logger;
     private slackClient: CommandClient;
-    private slackCommandHandlers: Command<KeeperSlackMiddleware, this>[];
+    private slackCommandHandlers: Command<MessageEvent, this>[];
 
     constructor(options: KeeperClientOptions) {
         this.logger = options.logger;

--- a/src/lib/clients/keeper.ts
+++ b/src/lib/clients/keeper.ts
@@ -1,4 +1,4 @@
-import { CommandClient, Command, Client } from '../../types/generic';
+import { CommandClient, Command } from '../../types/generic';
 import { KeeperClientOptions, KeeperSlackMiddleware } from '../../types/clients/keeper'
 import KeeperCommandHandlerMap from '../handlers/keeper';
 import { Logger } from '../../types/logger';
@@ -15,8 +15,8 @@ class KeeperClient implements CommandClient {
     }
 
     start = async (): Promise<void> => {
-        await this.slackClient.start();
         this.addDefaultCommandHandlers();
+        await this.slackClient.start();
         this.logger.log(`Started ${this.constructor.name}#start():SUCCESS`);
     }
 

--- a/src/lib/clients/phony.ts
+++ b/src/lib/clients/phony.ts
@@ -26,7 +26,10 @@ export default class PhonySlackClient implements CommandClient {
                         case "object": return matches.test(msg);
                         case "string": return matches == msg;
                     }
-                }).map(({ handler }) => {
+                }).map(({ requireMention, handler }) => {
+                    if (requireMention && msg.indexOf('@keeper') === -1) {
+                        return;
+                    }
                     return handler(this.handlerArgs(c, msg))
                 }));
             });

--- a/src/lib/clients/phony.ts
+++ b/src/lib/clients/phony.ts
@@ -1,6 +1,6 @@
 import { BaseOptions, HandlerBody } from '../../types/generic';
 import { SayArguments } from "@slack/bolt";
-import { KeeperSlackMiddleware } from "../../types/clients/keeper"
+import { MessageEvent } from "../../types/clients/keeper"
 import { CommandClient, Command } from '../../types/generic';
 import { Logger } from '../../types/logger'
 import * as net from 'net';
@@ -9,7 +9,7 @@ import { promisify } from 'util';
 export default class PhonySlackClient implements CommandClient {
     private logger: Logger;
     private server: net.Server;
-    private commands: Command<KeeperSlackMiddleware, this>[];
+    private commands: Command<MessageEvent, this>[];
 
     constructor(options: BaseOptions) {
         this.commands = [];
@@ -33,7 +33,7 @@ export default class PhonySlackClient implements CommandClient {
         });
     }
 
-    handlerArgs(c: net.Socket, text: string): HandlerBody<KeeperSlackMiddleware, this> {
+    handlerArgs(c: net.Socket, text: string): HandlerBody<MessageEvent, this> {
         return {
             client: this,
             logger: this.logger,

--- a/src/lib/clients/phony.ts
+++ b/src/lib/clients/phony.ts
@@ -45,7 +45,7 @@ export default class PhonySlackClient implements CommandClient {
                 },
                 message: {
                     channel: "#local",
-                    username: "Human",
+                    user: "Human",
                     text,
                 },
             },

--- a/src/lib/clients/phony.ts
+++ b/src/lib/clients/phony.ts
@@ -43,7 +43,7 @@ export default class PhonySlackClient implements CommandClient {
                     c.write(`keeper: ${text}\n`);
                     return { ok: true };
                 },
-                payload: {
+                message: {
                     channel: "#local",
                     username: "Human",
                     text,

--- a/src/lib/clients/slack.ts
+++ b/src/lib/clients/slack.ts
@@ -22,7 +22,7 @@ class SlackClient implements CommandClient {
 
     async start(): Promise<void> {
         await this._client.start({ port: this.port, host: '0.0.0.0' });
-        this.attachDefaultHandler;
+        this.attachDefaultHandler();
         this.logger.log(`Started SlackClient#start(): listening on port ${this.port}`);
     }
 
@@ -36,20 +36,26 @@ class SlackClient implements CommandClient {
     }
 
     private attachDefaultHandler = () => {
-        this._client.event("app_mention", async (args) => {
-            await Promise.all(this.commands.filter(({ matches }) => {
-                switch (typeof matches) {
-                    case "object": return matches.test(args.message);
-                    case "string": return matches == args.message;
-                }
-            }).map(({ handler }) => {
-                return handler({ client: this, command: args, logger: this.logger })
-            }));
+        // TODO: replace this with this._client.message() usage
+        // - https://slack.dev/bolt-js/concepts#message-listening
+        // this._client.event("app_mention", async (args) => {
+        //     await Promise.all(this.commands.filter(({ matches }) => {
+        //         switch (typeof matches) {
+        //             case "object": return matches.test(args.message);
+        //             case "string": return matches == args.message;
+        //         }
+        //     }).map(({ handler }) => {
+        //         return handler({ client: this, command: args, logger: this.logger })
+        //     }));
+        // });
+        this.commands.forEach(({ matches, handler }) => {
+            this.logger.log(`attaching handler for: ${matches}`);
+            this._client.message(matches, async (args) => {
+                this.logger.log(`message received! ${args}`);
+                await handler({ client: this, logger: this.logger, command: args });
+            });
         });
-        this._client.error((error: Error) => {
-            this.logger.error(error)
-            return Promise.resolve();
-        })
+        this._client.error(async (error: Error) => this.logger.error(error));
     }
 }
 

--- a/src/lib/clients/slack.ts
+++ b/src/lib/clients/slack.ts
@@ -36,22 +36,10 @@ class SlackClient implements CommandClient {
     }
 
     private attachDefaultHandler = () => {
-        // TODO: replace this with this._client.message() usage
-        // - https://slack.dev/bolt-js/concepts#message-listening
-        // this._client.event("app_mention", async (args) => {
-        //     await Promise.all(this.commands.filter(({ matches }) => {
-        //         switch (typeof matches) {
-        //             case "object": return matches.test(args.message);
-        //             case "string": return matches == args.message;
-        //         }
-        //     }).map(({ handler }) => {
-        //         return handler({ client: this, command: args, logger: this.logger })
-        //     }));
-        // });
         this.commands.forEach(({ matches, handler }) => {
             this.logger.log(`attaching handler for: ${matches}`);
             this._client.message(matches, async (args) => {
-                this.logger.log(`message received! ${args}`);
+                this.logger.log(`message received! ${JSON.stringify(args)}`);
                 await handler({ client: this, logger: this.logger, command: args });
             });
         });

--- a/src/lib/clients/slack.ts
+++ b/src/lib/clients/slack.ts
@@ -46,7 +46,7 @@ class SlackClient implements CommandClient {
                 await handler({ client: this, logger: this.logger, command: args });
             });
         });
-        this._client.error(async (error: Error) => this.logger.error(error));
+        this._client.error(this.logger.error);
     }
 
 }

--- a/src/lib/clients/slack.ts
+++ b/src/lib/clients/slack.ts
@@ -13,7 +13,6 @@ class SlackClient implements CommandClient {
         this._client = new App({
             signingSecret: options.signingSecret,
             token: options.token,
-            socketMode: true,
             appToken: options.appToken
         });
         this.commands = [];
@@ -22,8 +21,9 @@ class SlackClient implements CommandClient {
     }
 
     async start(): Promise<void> {
-        await this._client.start(this.port);
+        await this._client.start({ port: this.port, host: '0.0.0.0' });
         this.attachDefaultHandler;
+        this.logger.log(`Started SlackClient#start(): listening on port ${this.port}`);
     }
 
     async stop(): Promise<void> {

--- a/src/lib/clients/slack.ts
+++ b/src/lib/clients/slack.ts
@@ -39,7 +39,7 @@ class SlackClient implements CommandClient {
         this.commands.forEach(({ requireMention, matches, handler }) => {
             this.logger.log(`attaching handler for: ${matches}`);
             this._client.message(matches, async (args) => {
-                if (requireMention && !args.message.subtype && args.message.text?.indexOf('<@U03BJBGCGNQ>') === -1) {
+                if (requireMention && !args.message.subtype && args.message.text?.indexOf(`<@${args.context.botUserId}>`) === -1) {
                     return;
                 }
                 this.logger.log(`message received! ${JSON.stringify(args)}`);

--- a/src/lib/clients/slack.ts
+++ b/src/lib/clients/slack.ts
@@ -30,21 +30,25 @@ class SlackClient implements CommandClient {
         await this._client.stop()
     }
 
-    registerCommand({ matches, handler }: Command): SlackClient {
-        this.commands.push({ matches, handler });
+    registerCommand(command: Command): SlackClient {
+        this.commands.push(command);
         return this;
     }
 
     private attachDefaultHandler = () => {
-        this.commands.forEach(({ matches, handler }) => {
+        this.commands.forEach(({ requireMention, matches, handler }) => {
             this.logger.log(`attaching handler for: ${matches}`);
             this._client.message(matches, async (args) => {
+                if (requireMention && !args.message.subtype && args.message.text?.indexOf('<@U03BJBGCGNQ>') === -1) {
+                    return;
+                }
                 this.logger.log(`message received! ${JSON.stringify(args)}`);
                 await handler({ client: this, logger: this.logger, command: args });
             });
         });
         this._client.error(async (error: Error) => this.logger.error(error));
     }
+
 }
 
 export default SlackClient;

--- a/src/lib/handlers/keeper.ts
+++ b/src/lib/handlers/keeper.ts
@@ -1,23 +1,26 @@
 import { MessageEvent } from "../../types/clients/keeper"
-import { HandlerBody } from "../../types/generic";
+import { Handler } from "../../types/generic";
 import KeeperClient from "../clients/keeper"
 
-export const sayPong = async ({ logger, command: { say, message } }: HandlerBody<MessageEvent, KeeperClient>): Promise<void> => {
+type CommandHandler = Handler<MessageEvent, KeeperClient>;
+
+export const sayPong: CommandHandler = async ({ logger, command: { say, message } }) => {
     logger.log(`got ping: ${JSON.stringify(message.text)}`);
     await say(`Pong! -- ${message.text}`);
 }
 
-export const sayHello = async (args: HandlerBody<MessageEvent, KeeperClient>): Promise<void> => {
-    const { command: { say, message: { user } } } = args;
-    await say(`hello, <@${user}>!`);
+export const sayHello: CommandHandler = async ({ command: { say, message } }) => {
+    await say(`hello, <@${message.user}>!`);
 }
 
 export default [
     {
+        requireMention: true,
         matches: /ping/,
         handler: sayPong,
     },
     {
+        requireMention: false,
         matches: /hello/,
         handler: sayHello,
     },

--- a/src/lib/handlers/keeper.ts
+++ b/src/lib/handlers/keeper.ts
@@ -9,7 +9,7 @@ export const sayPong = async (args: HandlerBody<KeeperSlackMiddleware, KeeperCli
 
 export const sayHello = async (args: HandlerBody<KeeperSlackMiddleware, KeeperClient>): Promise<void> => {
     const { command: { say, message: { user } } } = args;
-    await say(`hello, ${user}!`);
+    await say(`hello, <@${user}>!`);
 }
 
 export default [

--- a/src/lib/handlers/keeper.ts
+++ b/src/lib/handlers/keeper.ts
@@ -8,17 +8,17 @@ export const sayPong = async (args: HandlerBody<KeeperSlackMiddleware, KeeperCli
 }
 
 export const sayHello = async (args: HandlerBody<KeeperSlackMiddleware, KeeperClient>): Promise<void> => {
-    const { command: { say, payload: { username } } } = args;
+    const { command: { say, message: { username } } } = args;
     await say(`hello, ${username}!`);
 }
 
 export default [
     {
-        matches: "ping",
+        matches: /ping/,
         handler: sayPong,
     },
     {
-        matches: /^hello/,
+        matches: /hello/,
         handler: sayHello,
     },
 ]

--- a/src/lib/handlers/keeper.ts
+++ b/src/lib/handlers/keeper.ts
@@ -8,8 +8,8 @@ export const sayPong = async (args: HandlerBody<KeeperSlackMiddleware, KeeperCli
 }
 
 export const sayHello = async (args: HandlerBody<KeeperSlackMiddleware, KeeperClient>): Promise<void> => {
-    const { command: { say, message: { username } } } = args;
-    await say(`hello, ${username}!`);
+    const { command: { say, message: { user } } } = args;
+    await say(`hello, ${user}!`);
 }
 
 export default [

--- a/src/lib/handlers/keeper.ts
+++ b/src/lib/handlers/keeper.ts
@@ -1,13 +1,13 @@
-import { KeeperSlackMiddleware } from "../../types/clients/keeper"
+import { MessageEvent } from "../../types/clients/keeper"
 import { HandlerBody } from "../../types/generic";
 import KeeperClient from "../clients/keeper"
 
-export const sayPong = async (args: HandlerBody<KeeperSlackMiddleware, KeeperClient>): Promise<void> => {
-    const { command: { say } } = args;
-    await say('Pong!');
+export const sayPong = async ({ logger, command: { say, message } }: HandlerBody<MessageEvent, KeeperClient>): Promise<void> => {
+    logger.log(`got ping: ${JSON.stringify(message.text)}`);
+    await say(`Pong! -- ${message.text}`);
 }
 
-export const sayHello = async (args: HandlerBody<KeeperSlackMiddleware, KeeperClient>): Promise<void> => {
+export const sayHello = async (args: HandlerBody<MessageEvent, KeeperClient>): Promise<void> => {
     const { command: { say, message: { user } } } = args;
     await say(`hello, <@${user}>!`);
 }

--- a/src/types/clients/keeper.ts
+++ b/src/types/clients/keeper.ts
@@ -15,7 +15,7 @@ export type MessageEvent = {
     matches?: AllMiddlewareArgs['context']['matches'],
     message: {
         channel: GenericMessageEvent['channel'],
-        username?: BotMessageEvent['username'],
+        user?: BotMessageEvent['user'],
         text?: GenericMessageEvent['text'],
     },
 };

--- a/src/types/clients/keeper.ts
+++ b/src/types/clients/keeper.ts
@@ -1,19 +1,23 @@
-import { SlackEventMiddlewareArgs } from "@slack/bolt";
+import { AllMiddlewareArgs, SlackEventMiddlewareArgs, GenericMessageEvent, BotMessageEvent } from "@slack/bolt";
 import { BaseOptions, CommandClient } from "../generic";
 
 export interface KeeperClientOptions extends BaseOptions {
     slackClient: CommandClient;
 }
 
+// type MessageEventMiddlewareArgs = AllMiddlewareArgs & GenericMessageEvent;
+
 // This is the type fed into the keeper handlers. If you need more data from
 // the Slack client, you can add those properties here, and will need to account for
 // them in the PhonySlackClient as well.
-export type AppMentionEvent = {
-    say: SlackEventMiddlewareArgs<'app_mention'>['say'],
-    payload: Pick<
-        SlackEventMiddlewareArgs<'app_mention'>['payload'],
-        'channel' | 'username' | 'text'
-    >
+export type MessageEvent = {
+    say: SlackEventMiddlewareArgs['say'],
+    matches?: AllMiddlewareArgs['context']['matches'],
+    message: {
+        channel: GenericMessageEvent['channel'],
+        username?: BotMessageEvent['username'],
+        text?: GenericMessageEvent['text'],
+    },
 };
 
-export type KeeperSlackMiddleware = AppMentionEvent;
+export type KeeperSlackMiddleware = MessageEvent;

--- a/src/types/clients/keeper.ts
+++ b/src/types/clients/keeper.ts
@@ -5,8 +5,6 @@ export interface KeeperClientOptions extends BaseOptions {
     slackClient: CommandClient;
 }
 
-// type MessageEventMiddlewareArgs = AllMiddlewareArgs & GenericMessageEvent;
-
 // This is the type fed into the keeper handlers. If you need more data from
 // the Slack client, you can add those properties here, and will need to account for
 // them in the PhonySlackClient as well.

--- a/src/types/clients/keeper.ts
+++ b/src/types/clients/keeper.ts
@@ -19,5 +19,3 @@ export type MessageEvent = {
         text?: GenericMessageEvent['text'],
     },
 };
-
-export type KeeperSlackMiddleware = MessageEvent;

--- a/src/types/generic.ts
+++ b/src/types/generic.ts
@@ -1,4 +1,4 @@
-import { KeeperSlackMiddleware } from './clients/keeper';
+import { MessageEvent } from './clients/keeper';
 import { Logger } from "./logger";
 
 export interface Startable {
@@ -19,7 +19,7 @@ export type HandlerBody<Command = any, Client = any> = { command: Command, clien
 
 export type Handler<Command = any, Client = any> = (args: HandlerBody<Command, Client>) => Promise<void>;
 
-export interface Command<Command = KeeperSlackMiddleware, Client = any> {
+export interface Command<Command = MessageEvent, Client = any> {
     matches: string | RegExp;
     handler: Handler<Command, Client>;
 }

--- a/src/types/generic.ts
+++ b/src/types/generic.ts
@@ -1,3 +1,4 @@
+import { KeeperSlackMiddleware } from './clients/keeper';
 import { Logger } from "./logger";
 
 export interface Startable {
@@ -18,7 +19,7 @@ export type HandlerBody<Command = any, Client = any> = { command: Command, clien
 
 export type Handler<Command = any, Client = any> = (args: HandlerBody<Command, Client>) => Promise<void>;
 
-export interface Command<Command = any, Client = any> {
+export interface Command<Command = KeeperSlackMiddleware, Client = any> {
     matches: string | RegExp;
     handler: Handler<Command, Client>;
 }

--- a/src/types/generic.ts
+++ b/src/types/generic.ts
@@ -17,9 +17,10 @@ export interface Client extends Startable, Stoppable { };
 
 export type HandlerBody<Command = any, Client = any> = { command: Command, client: Client, logger: Logger }
 
-export type Handler<Command = any, Client = any> = (args: HandlerBody<Command, Client>) => Promise<void>;
+export type Handler<Command = MessageEvent, Client = any> = (args: HandlerBody<Command, Client>) => Promise<void>;
 
 export interface Command<Command = MessageEvent, Client = any> {
+    requireMention: boolean;
     matches: string | RegExp;
     handler: Handler<Command, Client>;
 }


### PR DESCRIPTION
- Set up fly.toml config for deploying to fly.io
- Update the `Dockerfile` to expose port 3000
- Add a `.dockerignore` to keep certain files out of the image
- Add a `requireMention` flag to command handlers
- Some type reworking to match what is passed into the `app.message` handler middleware
- Ensure the slack client is being started properly, with command handlers registered
- Rename `KeeperSlackMiddleware` to just `MessageEvent`

[Issue](https://github.com/devict/keeper/issues/1#issue-1211524035)